### PR TITLE
Add alternate, environment variable-based docker-compose file

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,6 +9,7 @@ but keep in mind that for production usage it might need modifications.
 ## Directory layout
 
 * `docker-compose.yml`: the docker-compose file containing the services
+* `docker-compose-env.yml`: alternate docker-compose file using environment variables, can be run with the docker-compose `-f` flag
 * `configuration/lora*`: directory containing the LoRa Server configuration files, see:
     * https://www.loraserver.io/lora-gateway-bridge/install/config/
     * https://www.loraserver.io/loraserver/install/config/

--- a/docker-compose-env.yml
+++ b/docker-compose-env.yml
@@ -1,0 +1,55 @@
+version: "3"
+
+services:
+  loraserver:
+    image: loraserver/loraserver:2
+    environment:
+      - POSTGRESQL.DSN=postgres://loraserver_ns:loraserver_ns@postgresql/loraserver_ns?sslmode=disable
+      - REDIS.URL=redis://redis:6379
+      - NETWORK_SERVER.BAND.NAME=EU_863_870
+      - NETWORK_SERVER.GATEWAY.BACKEND.MQTT.SERVER=tcp://mosquitto:1883
+      - JOIN_SERVER.DEFAULT.SERVER=http://appserver:8003
+      - GEOLOCATION_SERVER.SERVER=geoserver:8005
+
+  appserver:
+    image: loraserver/lora-app-server:2
+    ports:
+      - 8080:8080
+    environment:
+      - POSTGRESQL.DSN=postgres://loraserver_as:loraserver_as@postgresql/loraserver_as?sslmode=disable
+      - REDIS.URL=redis://redis:6379
+      - APPLICATION_SERVER.INTEGRATION.MQTT.SERVER=tcp://mosquitto:1883
+      - APPLICATION_SERVER.API.PUBLIC_HOST=appserver:8001
+      - APPLICATION_SERVER.EXTERNAL_API.JWT_SECRET=verysecret
+
+  gatewaybridge:
+    image: loraserver/lora-gateway-bridge:2
+    ports:
+      - 1700:1700/udp
+    environment:
+      - BACKEND.MQTT.AUTH.GENERIC.SERVER=tcp://mosquitto:1883
+
+  geoserver:
+    image: loraserver/lora-geo-server:2
+    environment:
+      - GEO_SERVER.BACKEND.NAME=collos
+
+  postgresql:
+    image: postgres:9.6-alpine
+    volumes:
+      - ./configuration/postgresql/initdb:/docker-entrypoint-initdb.d
+      - postgresqldata:/var/lib/postgresql/data
+
+  redis:
+    image: redis:4-alpine
+    volumes:
+      - redisdata:/data
+
+  mosquitto:
+    image: eclipse-mosquitto
+    ports:
+      - 1883:1883
+
+volumes:
+  postgresqldata:
+  redisdata:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,12 +19,12 @@ services:
       - 1700:1700/udp
     volumes:
       - ./configuration/lora-gateway-bridge:/etc/lora-gateway-bridge
-  
+
   geoserver:
     image: loraserver/lora-geo-server:2
     volumes:
       - ./configuration/lora-geo-server:/etc/lora-geo-server
-  
+
   postgresql:
     image: postgres:9.6-alpine
     volumes:
@@ -44,4 +44,3 @@ services:
 volumes:
   postgresqldata:
   redisdata:
-


### PR DESCRIPTION
- Helpful for people getting started on Kubernetes or other env-based configurations.
- Update README.md and some errant spacing in the original `docker-compose.yml`.
